### PR TITLE
Issue 27 - add wireless timewarp settings

### DIFF
--- a/LeapMotion.uplugin
+++ b/LeapMotion.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "3.1.1",
+	"VersionName": "3.2.0",
 	"FriendlyName": "Leap Motion Plugin",
 	"Description": "Support for the Leap Motion input device.",
 	"Category": "Input Devices",

--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ Change leap policy. See [Leap Policies](https://developer.leapmotion.com/documen
 static void SetLeapPolicy(ELeapPolicyFlag Flag, bool Enable);
 ```
 
+## Wireless Adapter
+
+If you're using the Leap Motion with e.g. a Vive and a [Wireless Adapter](https://www.vive.com/us/wireless-adapter/) you need to adjust the timewarp settings via ```SetLeapOptions```. Change only the tracking Fidelity to ```Leap Wireless``` on e.g. begin play and then the plugin should correctly compensate for the increased latency from the wireless link.
+
+![setting wireless fidelity](https://i.imgur.com/v0yOqaL.png)
 
 ## Custom Rigging
 

--- a/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
+++ b/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
@@ -970,6 +970,26 @@ void FLeapMotionInputDevice::SetOptions(const FLeapOptions& InOptions)
 				Options.HandInterpFactor = -1.f;
 				Options.FingerInterpFactor = -1.f;
 				break;
+			case ELeapTrackingFidelity::LEAP_WIRELESS:
+				if (Stats.DeviceInfo.PID == TEXT("Peripheral"))
+				{
+					Options.bUseTimeWarp = true;
+					Options.bUseInterpolation = true;
+					Options.TimewarpOffset = 2000;
+					Options.TimewarpFactor = 1.f;
+					Options.HandInterpFactor = -1.2f;
+					Options.FingerInterpFactor = -1.2f;
+				}
+				else
+				{
+					Options.bUseTimeWarp = true;
+					Options.bUseInterpolation = true;
+					Options.TimewarpOffset = 0;
+					Options.TimewarpFactor = 1.f;
+					Options.HandInterpFactor = -0.8f;
+					Options.FingerInterpFactor = -0.8f;
+				}
+				break;
 			case ELeapTrackingFidelity::LEAP_CUSTOM:
 				break;
 			default:

--- a/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
+++ b/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
@@ -137,8 +137,9 @@ void FLeapMotionInputDevice::OnConnectionLost()
 
 void FLeapMotionInputDevice::OnDeviceFound(const LEAP_DEVICE_INFO *Props)
 {
-	SetOptions(Options);
 	Stats.DeviceInfo.SetFromLeapDevice((_LEAP_DEVICE_INFO*)Props);
+	SetOptions(Options);
+
 	LeapImageHandler->Reset();
 
 	UE_LOG(LeapMotionLog, Log, TEXT("OnDeviceFound %s %s."), *Stats.DeviceInfo.PID, *Stats.DeviceInfo.Serial);
@@ -975,19 +976,19 @@ void FLeapMotionInputDevice::SetOptions(const FLeapOptions& InOptions)
 				{
 					Options.bUseTimeWarp = true;
 					Options.bUseInterpolation = true;
-					Options.TimewarpOffset = 2000;
-					Options.TimewarpFactor = 1.f;
-					Options.HandInterpFactor = -1.2f;
-					Options.FingerInterpFactor = -1.2f;
+					Options.TimewarpOffset = 9500;
+					Options.TimewarpFactor = -1.f;
+					Options.HandInterpFactor = -1.6f;
+					Options.FingerInterpFactor = -1.6f;
 				}
 				else
 				{
-					Options.bUseTimeWarp = true;
+					Options.bUseTimeWarp = false;
 					Options.bUseInterpolation = true;
-					Options.TimewarpOffset = 0;
-					Options.TimewarpFactor = 1.f;
-					Options.HandInterpFactor = -0.8f;
-					Options.FingerInterpFactor = -0.8f;
+					Options.TimewarpOffset = 10000;
+					Options.TimewarpFactor = -1.f;
+					Options.HandInterpFactor = -0.75f;
+					Options.FingerInterpFactor = -0.75f;
 				}
 				break;
 			case ELeapTrackingFidelity::LEAP_CUSTOM:

--- a/Source/LeapMotion/Public/LeapMotionData.h
+++ b/Source/LeapMotion/Public/LeapMotionData.h
@@ -28,10 +28,11 @@ enum class ELeapImageType :uint8
 UENUM(BlueprintType)
 enum ELeapTrackingFidelity
 {
+	LEAP_CUSTOM,
 	LEAP_LOW_LATENCY,
 	LEAP_NORMAL,
 	LEAP_SMOOTH,
-	LEAP_CUSTOM
+	LEAP_WIRELESS
 };
 
 UENUM(BlueprintType)


### PR DESCRIPTION
Accessible via SetLeapOptions with the new Leap Wireless tracking fidelity.