### PR TITLE
removed html5 platform since it was deprecated by epic games, 4.24 support. 

### DIFF
--- a/LeapMotion.uplugin
+++ b/LeapMotion.uplugin
@@ -43,7 +43,6 @@
 				"Android",
 				"Mac",
 				"IOS",
-				"HTML5"
 			]
 		}
 	]


### PR DESCRIPTION
Removing the HTML5 platform from the .uplugin file allows the plugin to be recompiled for 4.24.