### PR TITLE
UNREAL-64 removed vive defaults for HMDPositionOffset and HMDRotation…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions
 * Removed some unsupported platforms.
 * Fixed a bug that forced desktop mode when vr headset is attached. 
 * Fixed freeing of device property before it is read causing invalid serials/devices. 
+* Fixed a bug where HMDPositionOffset and HMDRotationOffset settings for a Vive were being applied to all SteamVR headsets (Valve Index, Varjo, etc), if the value were set to zero - UNREAL-64
 * Fixed bad event usage example.
 * Updated hand colliders to be more accurate (now mesh based).
 * Resolved an issue where performance would decrease after a leap was unplugged/replugged.

--- a/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
+++ b/Source/LeapMotion/Private/FLeapMotionInputDevice.cpp
@@ -1177,17 +1177,6 @@ void FLeapMotionInputDevice::SetOptions(const FLeapOptions& InOptions)
 		if (HMDType == TEXT("SteamVR") ||
 			HMDType == TEXT("GearVR"))
 		{
-			//Apply default options to zero offsets/rotations
-			if (InOptions.HMDPositionOffset.IsNearlyZero())
-			{
-				FVector ViveOffset = FVector(9.0, 0, 0);
-				Options.HMDPositionOffset = ViveOffset;
-			}
-			if (InOptions.HMDRotationOffset.IsNearlyZero())
-			{
-				Options.HMDRotationOffset = FRotator(-10.f, 0, 0);	//typically vive mounts sag a bit
-			}
-
 			switch (InOptions.TrackingFidelity)
 			{
 			case ELeapTrackingFidelity::LEAP_LOW_LATENCY:


### PR DESCRIPTION
…Offset as these were being applied to all SteamVR headsets if not set