### PR TITLE
Update references and headers to avoid errors and warnings and enable to be used in UE5

### DIFF
--- a/Source/BodyState/Private/BodyStateAnimInstance.cpp
+++ b/Source/BodyState/Private/BodyStateAnimInstance.cpp
@@ -132,7 +132,7 @@ TMap<EBodyStateBasicBoneType, FBodyStateIndexedBone> UBodyStateAnimInstance::Aut
 
 	//Get bones and parent indices
 	USkeletalMesh* SkeletalMesh = Component->SkeletalMesh;
-	FReferenceSkeleton& RefSkeleton = SkeletalMesh->RefSkeleton;
+	FReferenceSkeleton& RefSkeleton = SkeletalMesh->GetRefSkeleton();
 
 	//Root bone
 	int32 RootBone = -2;

--- a/Source/BodyState/Private/BodyStateAnimInstance.cpp
+++ b/Source/BodyState/Private/BodyStateAnimInstance.cpp
@@ -132,8 +132,13 @@ TMap<EBodyStateBasicBoneType, FBodyStateIndexedBone> UBodyStateAnimInstance::Aut
 
 	//Get bones and parent indices
 	USkeletalMesh* SkeletalMesh = Component->SkeletalMesh;
-	FReferenceSkeleton& RefSkeleton = SkeletalMesh->GetRefSkeleton();
-
+	
+	#if ENGINE_MAJOR_VERSION >= 5
+		FReferenceSkeleton& RefSkeleton = SkeletalMesh->GetRefSkeleton();
+	#else
+		FReferenceSkeleton& RefSkeleton = SkeletalMesh->RefSkeleton;
+	#endif
+	
 	//Root bone
 	int32 RootBone = -2;
 

--- a/Source/BodyState/Private/BodyStateAnimInstance.cpp
+++ b/Source/BodyState/Private/BodyStateAnimInstance.cpp
@@ -214,6 +214,7 @@ TMap<EBodyStateBasicBoneType, FBodyStateIndexedBone> UBodyStateAnimInstance::Aut
 	{
 		bWristIsValid = BoneLookupList.Bones[WristBone].BoneName.ToString().ToLower().Contains(SearchStrings.WristSearchString);
 	}
+	
 	//We likely got the lower arm
 	if (!bWristIsValid)
 	{

--- a/Source/BodyState/Private/BodyStateAnimInstance.cpp
+++ b/Source/BodyState/Private/BodyStateAnimInstance.cpp
@@ -207,8 +207,13 @@ TMap<EBodyStateBasicBoneType, FBodyStateIndexedBone> UBodyStateAnimInstance::Aut
 
 	int32 WristBone = RefSkeleton.GetParentIndex(PalmBone);
 	int32 LowerArmBone = -1;
-	bool bWristIsValid = BoneLookupList.Bones[WristBone].BoneName.ToString().ToLower().Contains(SearchStrings.WristSearchString);
 	
+	bool bWristIsValid = false;
+
+	if (WristBone >= 0)
+	{
+		bWristIsValid = BoneLookupList.Bones[WristBone].BoneName.ToString().ToLower().Contains(SearchStrings.WristSearchString);
+	}
 	//We likely got the lower arm
 	if (!bWristIsValid)
 	{

--- a/Source/LeapMotion/Private/LeapImage.cpp
+++ b/Source/LeapMotion/Private/LeapImage.cpp
@@ -2,6 +2,7 @@
 
 #include "LeapImage.h"
 #include "LeapAsync.h"
+#include "Rendering/Texture2DResource.h"
 
 FLeapImage::FLeapImage()
 {

--- a/Source/LeapMotionEditor/Public/AnimGraphNode_ModifyBodyStateMappedBones.h
+++ b/Source/LeapMotionEditor/Public/AnimGraphNode_ModifyBodyStateMappedBones.h
@@ -3,7 +3,7 @@
 
 #include "AnimGraphDefinitions.h"
 #include "Kismet2/BlueprintEditorUtils.h"
-#include "Editor/AnimGraph/Classes/AnimGraphNode_SkeletalControlBase.h"
+#include "AnimGraphNode_SkeletalControlBase.h"
 
 #include "AnimNode_ModifyBodyStateMappedBones.h"
 // Copyright 1998-2020 Epic Games, Inc. All Rights Reserved.


### PR DESCRIPTION
_Source/BodyState/Private/BodyStateAnimInstance.cpp_ changes: **Avoid editor warnings about getting reference skeleton.**

_Source/LeapMotion/Private/LeapImage.cpp_ changes: **resolve error for undefined reference type FTexture2DResource.**

_Source/LeapMotionEditor/Public/AnimGraphNode_ModifyBodyStateMappedBones.h_ changes: **resolve error for cannot open source file**

This changes will resolve some errors, avoid warnings and enable the plugin to be used in UE5.